### PR TITLE
Remove the new lines that is causing some of json logs not exported to kibana

### DIFF
--- a/bin/uls.py
+++ b/bin/uls.py
@@ -193,7 +193,7 @@ def main():
         try:
             input_data = event_q.get(block=True, timeout=0.05)
             if uls_args.debugloglines:
-                escaped_data = input_data.decode('utf-8').replace('"', '\\"')
+                escaped_data = input_data.rstrip().decode('utf-8').replace('"', '\\"')
                 aka_log.log.debug(f"<IN> {escaped_data}")
             for log_line in input_data.splitlines():
 


### PR DESCRIPTION
Currently the <IN> messages are not going to kibana. The reason is because, input_data is having "new lines" at the end, and that is causing inconsistencies.

Previously, the <IN> messages are outputted this way:
```
{"@timestamp": "2024-09-30T19:33:37+0000", "level": "DEBUG", "type": "log", "data_version": 2, "application": "akamai-uls", "description": "<IN> {\"dir_id\": \"dir://kUz63dPlTcqPbWvhOrZokw\", \"service\": \"Cloud\", \"name\": \"Cloud Directory\", \"datetime\": \"2024-09-30T19:33:37.634987+00:00\", \"enabled\": true, \"connector_count\": 0, \"directory_status\": \"no_connector\", \"group_count\": 2, \"user_count\": 0, \"last_sync\": \"2024-02-13T19:49:39.568801\"}
", "roletype": "akauls"}
```

With the current fix, the <IN> messages are outputted in the below way:
```
{"@timestamp": "2024-09-30T19:35:50+0000", "level": "DEBUG", "type": "log", "data_version": 2, "application": "akamai-uls", "description": "<IN> {\"dir_id\": \"dir://kUz63dPlTcqPbWvhOrZokw\", \"service\": \"Cloud\", \"name\": \"Cloud Directory\", \"datetime\": \"2024-09-30T19:35:50.041007+00:00\", \"enabled\": true, \"connector_count\": 0, \"directory_status\": \"no_connector\", \"group_count\": 2, \"user_count\": 0, \"last_sync\": \"2024-02-13T19:49:39.568801\"}", "roletype": "akauls"}
```