### PR TITLE
Enhance JSON log escaping and adjust log level for a specific message

### DIFF
--- a/bin/modules/UlsOutput.py
+++ b/bin/modules/UlsOutput.py
@@ -464,12 +464,13 @@ class UlsOutput:
 
                             response.close()  # Free up the underlying TCP connection in the connection pool
 
+                    response_text_escaped = response.text.replace('"', '\\"')
                     aka_log.log.info(f"{self.name} HTTP POST of {len(self.aggregateList)} event(s) "
                                      f"completed in {(response.elapsed.total_seconds()*1000):.3f} ms, "
                                      f"payload={payload_length} bytes, HTTP response {response.status_code}, "
-                                     f"response={response.text} ")
+                                     f"response={response_text_escaped} ")
                     if response.status_code != uls_config.output_http_expected_status_code:
-                        aka_log.log.warning(f"{self.name} HTTP POST of {len(self.aggregateList)} was NOT successful. Statuscode: {response.status_code}, Error: {response.text}")
+                        aka_log.log.warning(f"{self.name} HTTP POST of {len(self.aggregateList)} was NOT successful. Statuscode: {response.status_code}, Error: {response_text_escaped}")
                         return False
                     self.aggregateList.clear()
                 else:
@@ -492,7 +493,7 @@ class UlsOutput:
                 aka_log.log.critical(f"{self.name} target was not defined {self.output_type} ")
                 sys.exit(1)
 
-            aka_log.log.debug(f"{self.name} Data successfully sent via {self.output_type}")
+            aka_log.log.info(f"{self.name} Data successfully sent via {self.output_type}")
             return True
 
         except Exception as my_error:


### PR DESCRIPTION
We noticed that some log messages were not being properly escaped, and this PR addresses that issue. Additionally, I've updated the log level of a specific message from `debug` to `info`, as it better aligns with its significance. We've set up monitoring to track whether ULS output data is successfully sent to Splunk based on this message. Since we only capture logs starting at the `info` level in production, this change will ensure that the message is visible in those environments. I hope you're okay with adjusting it to `info`.