### PR TITLE
Fix installer module gating, remove hard-coded `dev` branch, and align CLI documentation

### DIFF
--- a/docs/COMMAND_LINE_USAGE.md
+++ b/docs/COMMAND_LINE_USAGE.md
@@ -30,7 +30,7 @@ To run the operations in this documentation, make sure you have the following to
 - Understanding of available [ULS CLI PARAMETERS](ARGUMENTS_ENV_VARS.md)
 - Access to `github.com`, `uls-beacon.akamaized.net`, `pypi.org`, `pythonhosted.org`, `pypi.python.org` as well as your Akamai API hostname (see edgerc) within your firewall
 
-The above apploes as well for Linux and Windows OS.
+The above applies as well for Linux and Windows OS.
 
 ## Installation
 
@@ -85,7 +85,7 @@ git clone -q --depth 1 --single-branch https://github.com/MikeSchiessl/ln-logs.g
 pip3 install -q -r ext/cli-linode/bin/requirements.txt
 
 # Akamai Control Center Events (experimental)
-git clone -q --depth 1 -b dev --single-branch https://github.com/MikeSchiessl/acc-logs.git ext/acc-logs && \
+git clone -q --depth 1 --single-branch https://github.com/MikeSchiessl/acc-logs.git ext/acc-logs && \
 pip3 install -q -r ext/acc-logs/bin/requirements.txt
 ```
 
@@ -134,11 +134,11 @@ All log output will be directed to STDOUT by default.
     ```
   Rather consider [docker usage](./DOCKER_USAGE.md) instead of this  
 
-
 - ACC EventViewer LOG ==> RAW with starting time
     ```bash
     python3 bin/uls.py --input ACC -f events --section default --starttime 1719852040 --output raw
     ``` 
+
 ## ULS as a service: systemd
 
 If you are planning to use multiple Akamai feed with ULS, bear in mind you will need to repeat the instruction below multiple times. We built this guide with CentOS 7.
@@ -242,5 +242,5 @@ pip3 install -q -r ext/cli-mfa/requirements.txt
 
 # ACC EventViewer (only if installed)
 git -C ext/acc-logs pull -q
-pip3 install -q -r ext/acc-logs/requirements.txt 
+pip3 install -q -r ext/acc-logs/bin/requirements.txt 
 ```

--- a/scripts/get-uls.sh
+++ b/scripts/get-uls.sh
@@ -37,6 +37,7 @@ Available ULS modules:
   mfa: Akamai phishproof MFA
   gc:  Akamai Guardicore Segmentation
   ln:  Linode Audit log
+  acc: Akamai Control Center Events (experimental)
 
 More about supported feed: 
 https://github.com/akamai/uls/blob/main/docs/LOG_OVERVIEW.md"
@@ -86,7 +87,6 @@ echo -ne "python3: \t $(ls $(which python3))\n"
 echo -ne "pip3: \t\t $(ls $(which pip3))\n\n"
 echo -ne "Is this correct (Y|n)"
 read py_reply
-
 
 case $py_reply in
   n|N)
@@ -145,7 +145,6 @@ fi
 git clone -q https://github.com/akamai/uls.git $install_dir/
 pip3 install -q -r ${install_dir}/bin/requirements.txt
 
-
 function py_reqs() {
   to_install=$(pip3 install --dry-run -r $1 | grep -vi "satisfied")
   if [[ ! -z $to_install ]] ; then
@@ -172,7 +171,6 @@ function py_reqs() {
 if [[ "$install_modules" == *"eaa"* ]]  ; then
 echo "Installing EAA-CLI"
   git clone -q --depth 1 --single-branch https://github.com/akamai/cli-eaa.git ${install_dir}/ext/cli-eaa
-  #echo "${install_dir}/ext/cli-eaa/requirements.txt"
   py_reqs ${install_dir}/ext/cli-eaa/requirements.txt
   pip3 install -q -r ${install_dir}/ext/cli-eaa/requirements.txt
 fi 
@@ -181,7 +179,7 @@ fi
 if [[ "$install_modules" == *"etp"* ]]  ; then
 echo "Installing ETP-CLI"
   git clone -q --depth 1 --single-branch https://github.com/akamai/cli-etp.git ${install_dir}/ext/cli-etp
- py_reqs ${install_dir}/ext/cli-etp/requirements.txt
+  py_reqs ${install_dir}/ext/cli-etp/requirements.txt
   pip3 install -q -r ${install_dir}/ext/cli-etp/requirements.txt
 fi
 
@@ -201,27 +199,26 @@ echo "Installing GC-CLI"
   pip3 install -q -r ${install_dir}/ext/cli-gc/bin/requirements.txt
 fi
 
-## GRAB LINODE-CLI
-if [[ "$install_modules" == *"acc"* ]]  ; then
-echo "Installing ACC-CLI"
-  git clone -q --depth 1 --single-branch https://github.com/MikeSchiessl/acc-logs.git ${install_dir}/ext/cli-linode
+## GRAB LINODE-CLI (ln)
+if [[ "$install_modules" == *"ln"* ]]  ; then
+echo "Installing LINODE-CLI"
+  git clone -q --depth 1 --single-branch https://github.com/MikeSchiessl/ln-logs.git ${install_dir}/ext/cli-linode
   py_reqs ${install_dir}/ext/cli-linode/bin/requirements.txt
   pip3 install -q -r ${install_dir}/ext/cli-linode/bin/requirements.txt
 fi
 
-## GRAB ACC-CLI
-if [[ "$install_modules" == *"gc"* ]]  ; then
+## GRAB ACC-CLI (acc)
+if [[ "$install_modules" == *"acc"* ]]  ; then
 echo "Installing ACC-CLI"
-  git clone -q --depth 1 -b dev --single-branch https://github.com/MikeSchiessl/acc-logs.git ${install_dir}/ext/acc-logs
+  # Do not hard-code branch "dev" (may not exist)
+  git clone -q --depth 1 --single-branch https://github.com/MikeSchiessl/acc-logs.git ${install_dir}/ext/acc-logs
   py_reqs ${install_dir}/ext/acc-logs/bin/requirements.txt
   pip3 install -q -r ${install_dir}/ext/acc-logs/bin/requirements.txt
 fi
-
 
 # Finishing off
 echo -e "\n\n\n"
 echo "ULS has been successfully installed"
 ${install_dir}/bin/uls.py --version
-
 
 exit 0


### PR DESCRIPTION
# PR Description

## Summary
This PR fixes two related issues affecting the ULS installer and the command line documentation:

1) The installer (`scripts/get-uls.sh`) incorrectly triggers ACC installation when only `gc` is selected and also hard-codes cloning `acc-logs` from a `dev` branch that may not exist.  
2) The documentation (`docs/COMMAND_LINE_USAGE.md`) contains the same hard-coded `-b dev` reference and an incorrect ACC requirements path in the update instructions.

These issues can cause install failures (e.g., `fatal: Remote branch dev not found`) and inconsistent guidance.

## Changes

### `scripts/get-uls.sh`
- Add missing `acc` entry to the “Available ULS modules” section.
- Fix module gating and repository mapping:
  - `ln` installs the Linode log fetcher (`ln-logs`) into `ext/cli-linode`
  - `acc` installs ACC EventViewer (`acc-logs`) into `ext/acc-logs`
  - Selecting `gc` no longer triggers ACC installation
- Remove hard-coded `-b dev` from the `acc-logs` clone (use default branch).

### `docs/COMMAND_LINE_USAGE.md`
- Remove `-b dev` from the ACC (experimental) clone command.
- Fix typo: `apploes` → `applies`.
- Fix ACC update instructions to use the correct requirements path:
  - `ext/acc-logs/requirements.txt` → `ext/acc-logs/bin/requirements.txt`

## How to test
- Run `scripts/get-uls.sh` and select `gc` only:
  - Confirm it does **not** attempt to install ACC.
  - Confirm it does **not** try to clone `acc-logs` with `-b dev`.
- (Optional) Select `ln` or `acc`:
  - Confirm the correct repository is cloned into the correct directory and requirements are installed from the expected path.

## Notes
No changes are included for Python environment management (e.g., venv/PEP 668). This PR focuses strictly on the `dev` branch reference, module gating, and documentation alignment.
